### PR TITLE
Add config nodes for Rockomax parts in career mode

### DIFF
--- a/GameData/ProceduralFairings/Config/PF_Settings_Config.cfg
+++ b/GameData/ProceduralFairings/Config/PF_Settings_Config.cfg
@@ -12,6 +12,7 @@ PROCFAIRINGS_MINDIAMETER
 PROCFAIRINGS_MAXDIAMETER
 {
     start = 1.50
+    specializedConstruction = 2.75
     advAerodynamics = 4.0
     heavyAerodynamics = 12.0
     experimentalAerodynamics = 30.0
@@ -57,6 +58,26 @@ PART
     title = Procedural Fairings Upgrade
     manufacturer = Keramzit Engineering
     description = Allows fairings and plates to be made as small as 0.4 meters.
+}
+
+PART
+{
+    name = pf_tech_fairing2_75m
+    module = Part
+    author = Starstrider42 (config), e-dog (model)
+
+    MODEL
+    {
+        model = ProceduralFairings/Parts/base_standard
+    }
+
+    TechRequired = specializedConstruction
+    entryCost = 0
+    cost = 0
+    category = none
+    title = Procedural Fairings Upgrade
+    manufacturer = Keramzit Engineering
+    description = Allows fairings bases up to 2.75 meters.
 }
 
 PART


### PR DESCRIPTION
Squad included the 2.5m fairing under `Specialized Construction` in the tech tree.

Unlocking it, I had expected to be able to expand PF out to 2.5m, but it didn't.

Modded the config. Figured I might as well PR it up, if you guys want to include it in the future.